### PR TITLE
Make enum field of the Server Variable Object optional

### DIFF
--- a/lib/src/v3/server.dart
+++ b/lib/src/v3/server.dart
@@ -67,7 +67,9 @@ class APIServerVariable extends APIObject {
   void decode(KeyedArchive object) {
     super.decode(object);
 
-    availableValues = List<String>.from(object.decode("enum"));
+    availableValues = object.decode("enum") != null
+        ? List<String>.from(object.decode("enum"))
+        : null;
     defaultValue = object.decode("default");
     description = object.decode("description");
   }

--- a/test/v3_test.dart
+++ b/test/v3_test.dart
@@ -261,6 +261,22 @@ void main() {
     });
   });
 
+  test("Server Variable enum is optional", () {
+    final doc = APIDocument.fromMap({
+      "servers": [
+        {
+          "url": "https://{host}/path",
+          "variables": {
+            "host": {"default": "example.com"}
+          }
+        }
+      ],
+      "info": {}
+    });
+
+    expect(doc.servers!.first!.variables!["host"]!.availableValues, isNull);
+  });
+
   group("Callbacks", () {});
 
   group("'add' methods", () {


### PR DESCRIPTION
According to the [OpenAPI spec](https://spec.openapis.org/oas/v3.1.1.html#server-object) the
`enum` field of the Server Variable object is optional (and when it's present it must be a non-empty array).

Before this change, when parsing an OpenAPI document where a Server Variable object is present without the `enum` field, this error would be thrown:

```
type 'Null' is not a subtype of type 'Iterable<dynamic>'
package:open_api_forked/src/v3/server.dart 73:48 APIServerVariable.decode
```

This change makes it possible to parse such document and the resulting `availableValues` is `null`.
